### PR TITLE
Update to g4.2.2 and added network access

### DIFF
--- a/org.zdoom.GZDoom.appdata.xml
+++ b/org.zdoom.GZDoom.appdata.xml
@@ -73,6 +73,11 @@
   <releases>
     <release version="4.2.1" date="2019-09-11">
       <description>
+        <p>Updated release package to GZDoom 4.2.2</p>
+      </description>
+    </release>
+    <release version="4.2.1" date="2019-09-11">
+      <description>
         <p>Updated release package to GZDoom 4.2.1 and made many minor changes for Flathub.</p>
       </description>
     </release>

--- a/org.zdoom.GZDoom.appdata.xml
+++ b/org.zdoom.GZDoom.appdata.xml
@@ -71,7 +71,7 @@
   </screenshots>
 
   <releases>
-    <release version="4.2.1" date="2019-09-11">
+    <release version="4.2.2" date="2019-10-20">
       <description>
         <p>Updated release package to GZDoom 4.2.2</p>
       </description>

--- a/org.zdoom.GZDoom.appdata.xml
+++ b/org.zdoom.GZDoom.appdata.xml
@@ -71,9 +71,9 @@
   </screenshots>
 
   <releases>
-    <release version="4.2.2" date="2019-10-20">
+    <release version="4.2.3" date="2019-10-20">
       <description>
-        <p>Updated release package to GZDoom 4.2.2</p>
+        <p>Updated release package to GZDoom 4.2.3 (4.2.2 was cancelled)</p>
       </description>
     </release>
     <release version="4.2.1" date="2019-09-11">

--- a/org.zdoom.GZDoom.yaml
+++ b/org.zdoom.GZDoom.yaml
@@ -10,6 +10,7 @@ finish-args:
 - --socket=fallback-x11
 - --socket=x11
 - --share=ipc
+- --share=network
 - --socket=pulseaudio
 
 # Based on GZDoom
@@ -68,8 +69,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/coelckers/gzdoom.git
-    tag: g4.2.1
-    commit: f586196f28ae099255ea15e9e69ac19b218f5cdf
+    tag: g4.2.2
+    commit: 2d62608d55ffdead41aafa20fae855fc911013a7
   - type: file
     url: https://github.com/coelckers/gzdoom/raw/g4.2.1/soundfont/gzdoom.sf2
     sha256: fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869

--- a/org.zdoom.GZDoom.yaml
+++ b/org.zdoom.GZDoom.yaml
@@ -69,8 +69,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/coelckers/gzdoom.git
-    tag: g4.2.2
-    commit: 2d62608d55ffdead41aafa20fae855fc911013a7
+    tag: g4.2.3
+    commit: d5ff2746be69636ed17c197877407ee2ad12b8f7
   - type: file
     url: https://github.com/coelckers/gzdoom/raw/g4.2.1/soundfont/gzdoom.sf2
     sha256: fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869


### PR DESCRIPTION
Network support was mentioned in all documentation and even the age rating, but the share=network was never set.